### PR TITLE
Fix typo: `file_extentions` -> `file_extensions`

### DIFF
--- a/LinkerScript.sublime-syntax
+++ b/LinkerScript.sublime-syntax
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 name: Linker Script
-file_extentions: [ld]
+file_extensions: [ld]
 scope: source.linker
 
 variables:


### PR DESCRIPTION
Found by @Keats